### PR TITLE
Add separate test jobs for macOS and Linux in GitHub Actions workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,8 +8,33 @@ on:
 
 jobs:
   test:
-    name: Run Tests
+    name: Run Tests (macOS)
     runs-on: macos-latest
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - uses: swift-actions/setup-swift@v2
+      with:
+        swift-version: "6.1.0"
+      
+    - name: Resolve dependencies
+      run: swift package resolve
+      
+    - name: Build project
+      run: swift build -v
+      
+    - name: Run tests
+      env:
+        DIFY_API_KEY: ${{ secrets.DIFY_API_KEY }}
+        DIFY_BASE_URL: ${{ secrets.DIFY_BASE_URL }}
+        DIFY_USER_ID: ${{ secrets.DIFY_USER_ID }}
+      run: swift test -v
+
+  test-linux:
+    name: Run Tests (Linux)
+    runs-on: ubuntu-latest
     
     steps:
     - name: Checkout code


### PR DESCRIPTION
Introduce distinct test jobs for macOS and Linux to enhance the CI process in GitHub Actions. This change allows for more targeted testing across different environments.