### PR TITLE
Update generic constraints to include Sendable for streaming responses

### DIFF
--- a/Sources/DifySwiftClient/DifySwiftClient.swift
+++ b/Sources/DifySwiftClient/DifySwiftClient.swift
@@ -98,7 +98,7 @@ open class DifyClient: @unchecked Sendable {
     }
 
     /// Creates an `AsyncThrowingStream` for a streaming API endpoint.
-    internal func createStreamingResponse<T: Decodable>(for request: URLRequest) async throws -> AsyncThrowingStream<T, Error> {
+    internal func createStreamingResponse<T: Decodable & Sendable>(for request: URLRequest) async throws -> AsyncThrowingStream<T, Error> {
         // Check if we're running in a test environment with MockURLProtocol
         let isTestEnvironment = session.configuration.protocolClasses?.contains { protocolClass in
             NSStringFromClass(protocolClass) == "DifySwiftClientTests.MockURLProtocol"
@@ -121,7 +121,7 @@ open class DifyClient: @unchecked Sendable {
     
     #if !canImport(FoundationNetworking)
     /// Creates streaming response using URLSession.bytes (for production use on Apple platforms)
-    private func createStreamingResponseUsingBytes<T: Decodable>(for request: URLRequest) async throws -> AsyncThrowingStream<T, Error> {
+    private func createStreamingResponseUsingBytes<T: Decodable & Sendable>(for request: URLRequest) async throws -> AsyncThrowingStream<T, Error> {
         let (bytes, response) = try await session.bytes(for: request)
         
         guard let httpResponse = response as? HTTPURLResponse else {
@@ -169,7 +169,7 @@ open class DifyClient: @unchecked Sendable {
     #endif
     
     /// Creates streaming response using data task (for test compatibility with URLProtocol and Linux support)
-    private func createStreamingResponseUsingDataTask<T: Decodable>(for request: URLRequest) async throws -> AsyncThrowingStream<T, Error> {
+    private func createStreamingResponseUsingDataTask<T: Decodable & Sendable>(for request: URLRequest) async throws -> AsyncThrowingStream<T, Error> {
         // First perform the request to get the data
         let (data, response) = try await session.data(for: request)
         

--- a/Tests/DifySwiftClientTests/TestInfrastructure/DifyTestCase.swift
+++ b/Tests/DifySwiftClientTests/TestInfrastructure/DifyTestCase.swift
@@ -206,7 +206,7 @@ extension DifyTestCase {
     }
     
     /// Test streaming response
-    func testStreamingResponse<T: Decodable, B: Codable>(
+    func testStreamingResponse<T: Decodable & Sendable, B: Codable>(
         client: DifyClient,
         endpoint: String,
         method: HTTPMethod = .POST,

--- a/Tests/DifySwiftClientTests/TestInfrastructure/MockURLProtocol.swift
+++ b/Tests/DifySwiftClientTests/TestInfrastructure/MockURLProtocol.swift
@@ -5,7 +5,7 @@ import FoundationNetworking
 
 /// MockURLProtocol intercepts all HTTP requests during tests and returns mock responses
 /// This allows us to test without any real network calls
-final class MockURLProtocol: URLProtocol, @unchecked Sendable {
+final class MockURLProtocol: URLProtocol {
     
     /// Storage for mock responses keyed by request
     private nonisolated(unsafe) static var mockResponses: [MockRequest: MockResponse] = [:]


### PR DESCRIPTION
Enhance type safety by updating generic constraints in streaming response methods to require Sendable. This change ensures compatibility with concurrent programming models.